### PR TITLE
close connections to address resource warnings

### DIFF
--- a/tests/test_fsa_lite.py
+++ b/tests/test_fsa_lite.py
@@ -12,20 +12,6 @@ from sqlalchemy.orm import DeclarativeBase
 from flask_alembic import Alembic
 
 
-@pytest.fixture
-def app(app: Flask) -> Flask:
-    app.config["SQLALCHEMY_ENGINES"] = {
-        "default": "sqlite://",
-        "other": "sqlite://",
-    }
-    return app
-
-
-@pytest.fixture
-def db(app: Flask) -> SQLAlchemy:
-    return SQLAlchemy(app)
-
-
 class Model(DeclarativeBase):
     pass
 
@@ -54,11 +40,14 @@ def test_uses_engines(app: Flask) -> None:
 def test_engine_required(app: Flask) -> None:
     """Flask-SQLAlchemy-Lite must configure an engine."""
     del app.config["SQLALCHEMY_ENGINES"]
-    SQLAlchemy(app, require_default_engine=False)
+    db = SQLAlchemy(app, require_default_engine=False)
     alembic = Alembic(app, metadatas=Model.metadata)
 
     with pytest.raises(RuntimeError, match="engines configured"):
         assert alembic.migration_context
+
+    for engine in db.engines.values():
+        engine.dispose()
 
 
 @pytest.mark.usefixtures("app_ctx", "db")
@@ -80,3 +69,5 @@ def test_override_engines(tmp_path: Path, app: Flask) -> None:
     alembic = Alembic(app, metadatas=Model.metadata, engines=engine)
     assert alembic.migration_context.connection is not None
     assert alembic.migration_context.connection.engine.url.database == db_path
+    alembic.migration_context.connection.close()
+    engine.dispose()

--- a/tests/test_plain_sa.py
+++ b/tests/test_plain_sa.py
@@ -45,6 +45,8 @@ def test_valid_config(app: Flask) -> None:
         engines={"default": engine, "other": other_engine},
     )
     assert len(alembic.migration_contexts) == 2
+    engine.dispose()
+    other_engine.dispose()
 
 
 @pytest.mark.usefixtures("app_ctx")
@@ -59,3 +61,5 @@ def test_missing_engine(app: Flask) -> None:
 
     with pytest.raises(RuntimeError, match="Missing engine config"):
         assert alembic.migration_context
+
+    engine.dispose()


### PR DESCRIPTION
Sqlite3 raises a resource warning if the connection is still open when `Connection.__del__` is called. Because gc isn't predictable, this can appear as an unrelated test failing during pytest's teardown phase. SQLAlchemy's engine/pool will hold on to the connection, which is desirable except in tests.

Add a call to `gc.collect()` at the end of the `app` fixture to try to make this more predictable, although it doesn't seem to work for all cases. Add calls to `engine.dispose()` for the extension's engines, and any manually created engines. Also need to call `connection.close()` for a couple tests, even though this _should_ be happening in the extension's `teardown_appcontext` function.

fixes #47 