### PR TITLE
call `connection.invalidate` instead of `close`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,9 @@ Unreleased
 -   Drop support for Python 3.9.
 -   Remove previously deprecated code.
     -   `init_app` args `run_mkdir` and `command_name` are removed.
+-   Call `invalidate` instead of `close` on the connection used by the migration
+    context. This seems to fix resource warnings from sqlite3 during tests.
+    {issue}`47`
 -   Add `path_separator` to config to suppress Alembic warning. {issue}`48`
 
 ## Version 3.1.1

--- a/src/flask_alembic/extension.py
+++ b/src/flask_alembic/extension.py
@@ -752,7 +752,7 @@ class _Cache:
         if self.contexts is not None:
             for context in self.contexts.values():
                 if context.connection is not None:
-                    context.connection.close()
+                    context.connection.invalidate()
 
         self.contexts = None
         self.ops = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import collections.abc as c
-import gc
 import os
 from pathlib import Path
 
@@ -14,14 +13,13 @@ from flask_alembic import Alembic
 
 
 @pytest.fixture
-def app(request: pytest.FixtureRequest, tmp_path: Path) -> c.Iterator[Flask]:
+def app(request: pytest.FixtureRequest, tmp_path: Path) -> Flask:
     app = Flask(request.module.__name__, root_path=os.fspath(tmp_path))
     app.config["SQLALCHEMY_ENGINES"] = {
         "default": "sqlite://",
         "other": "sqlite://",
     }
-    yield app
-    gc.collect()
+    return app
 
 
 @pytest.fixture
@@ -32,12 +30,7 @@ def app_ctx(app: Flask) -> c.Iterator[AppContext]:
 
 @pytest.fixture
 def db(app: Flask) -> c.Iterator[SQLAlchemy]:
-    db = SQLAlchemy(app)
-    yield db
-
-    with app.app_context():
-        for engine in db.engines.values():
-            engine.dispose()
+    yield SQLAlchemy(app)
 
 
 @pytest.fixture

--- a/tests/test_fsa.py
+++ b/tests/test_fsa.py
@@ -22,10 +22,6 @@ def db(app: Flask) -> c.Iterator[SQLAlchemy]:
     db = SQLAlchemy(app)
     yield db
 
-    with app.app_context():
-        for engine in db.engines.values():
-            engine.dispose()
-
 
 @pytest.fixture
 def Book(db: SQLAlchemy) -> type[t.Any]:
@@ -70,5 +66,3 @@ def test_override_engines(tmp_path: Path, app: Flask, db: SQLAlchemy) -> None:
     alembic = Alembic(app, engines=engine)
     assert alembic.migration_context.connection is not None
     assert alembic.migration_context.connection.engine.url.database == db_path
-    alembic.migration_context.connection.close()
-    engine.dispose()

--- a/tests/test_fsa_lite.py
+++ b/tests/test_fsa_lite.py
@@ -40,14 +40,11 @@ def test_uses_engines(app: Flask) -> None:
 def test_engine_required(app: Flask) -> None:
     """Flask-SQLAlchemy-Lite must configure an engine."""
     del app.config["SQLALCHEMY_ENGINES"]
-    db = SQLAlchemy(app, require_default_engine=False)
+    SQLAlchemy(app, require_default_engine=False)
     alembic = Alembic(app, metadatas=Model.metadata)
 
     with pytest.raises(RuntimeError, match="engines configured"):
         assert alembic.migration_context
-
-    for engine in db.engines.values():
-        engine.dispose()
 
 
 @pytest.mark.usefixtures("app_ctx", "db")
@@ -69,5 +66,3 @@ def test_override_engines(tmp_path: Path, app: Flask) -> None:
     alembic = Alembic(app, metadatas=Model.metadata, engines=engine)
     assert alembic.migration_context.connection is not None
     assert alembic.migration_context.connection.engine.url.database == db_path
-    alembic.migration_context.connection.close()
-    engine.dispose()

--- a/tests/test_plain_sa.py
+++ b/tests/test_plain_sa.py
@@ -45,8 +45,6 @@ def test_valid_config(app: Flask) -> None:
         engines={"default": engine, "other": other_engine},
     )
     assert len(alembic.migration_contexts) == 2
-    engine.dispose()
-    other_engine.dispose()
 
 
 @pytest.mark.usefixtures("app_ctx")
@@ -61,5 +59,3 @@ def test_missing_engine(app: Flask) -> None:
 
     with pytest.raises(RuntimeError, match="Missing engine config"):
         assert alembic.migration_context
-
-    engine.dispose()


### PR DESCRIPTION
This seems to be a better fix for the sqlite resource warnings reported in #47. Previously in #51, I peppered the tests with `engine.dispose` calls. But while working on another feature, a test started showing a warning about a different connection issue. After some investigation, it seems like `invalidate` cleans up the connection and engine/pool better, so the `dispose` calls aren't needed, and this should fix everyone else's test suites as well. I don't really understand SQLAlchemy at this level, but as far as I can tell everything still works.