### PR TITLE
implement check-heads option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@ Unreleased
     it as a relative count. {issue}`45`
 -   Implement `check` CLI command and corresponding `needs_revision` method.
     {issue}`33`
+-   Implement `current --check-heads` CLI command and corresponding
+    `needs_upgrade` method.
 
 ## Version 3.1.1
 

--- a/src/flask_alembic/cli.py
+++ b/src/flask_alembic/cli.py
@@ -26,9 +26,24 @@ def mkdir(alembic: Alembic) -> None:
 
 @cli.command()
 @click.pass_obj
+@click.pass_context
+@click.option(
+    "--check-heads",
+    is_flag=True,
+    help="Check if all head revisions are applied.",
+)
 @click.option("-v", "--verbose", is_flag=True)
-def current(alembic: Alembic, verbose: bool = False) -> None:
+def current(
+    ctx: click.Context,
+    alembic: Alembic,
+    check_heads: bool = False,
+    verbose: bool = False,
+) -> None:
     """Show the list of current revisions."""
+    if check_heads and alembic.needs_upgrade():
+        click.echo("Database is not on all head revisions")
+        ctx.exit(1)
+
     for r in alembic.current():
         if r is None:
             click.echo("None")
@@ -89,11 +104,12 @@ def show(alembic: Alembic, revisions: list[str]) -> None:
 
 @cli.command()
 @click.pass_obj
-def check(alembic: Alembic) -> None:
+@click.pass_context
+def check(ctx: click.Context, alembic: Alembic) -> None:
     """Check if any changes between the database and models are detected."""
     if alembic.needs_revision():
         click.echo("Changes detected.")
-        raise click.exceptions.Exit(1)
+        ctx.exit(1)
     else:
         click.echo("No changes detected.")
 

--- a/src/flask_alembic/extension.py
+++ b/src/flask_alembic/extension.py
@@ -448,6 +448,16 @@ class Alembic:
             self.migration_context.get_current_heads()
         )
 
+    def needs_upgrade(self) -> bool:
+        """Check whether the current revisions are the head revisions.
+
+        :return: ``True`` if the database is not at all head revisions,
+            ``False`` otherwise.
+        """
+        current_revs = {r.revision for r in self.current()}
+        head_revs = {r.revision for r in self.heads()}
+        return current_revs != head_revs
+
     def heads(self, resolve_dependencies: bool = False) -> tuple[Script, ...]:
         """Get the list of revisions that have no child revisions.
 

--- a/tests/cli/test_current.py
+++ b/tests/cli/test_current.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pytest
+from flask.testing import FlaskCliRunner
+
+from flask_alembic import Alembic
+
+
+@pytest.mark.usefixtures("app_ctx")
+def test_needs_upgrade_at_head(alembic: Alembic) -> None:
+    alembic.upgrade()
+    assert not alembic.needs_upgrade()
+
+
+@pytest.mark.usefixtures("app_ctx")
+def test_needs_upgrade_not_at_head(alembic: Alembic) -> None:
+    alembic.upgrade(1)
+    assert alembic.needs_upgrade()
+
+
+@pytest.mark.usefixtures("app_ctx")
+def test_check_heads_at_head(alembic: Alembic, runner: FlaskCliRunner) -> None:
+    alembic.upgrade()
+    result = runner.invoke(args=["db", "current", "--check-heads"])
+    assert result.exit_code == 0
+
+
+@pytest.mark.usefixtures("app_ctx")
+def test_check_heads_not_at_head(alembic: Alembic, runner: FlaskCliRunner) -> None:
+    alembic.upgrade(1)
+    result = runner.invoke(args=["db", "current", "--check-heads"])
+    assert result.exit_code == 1
+    assert "Database is not on all head revisions" in result.output


### PR DESCRIPTION
Noticed another check, `current --check-heads` when implementing `check` in #56.