### PR TITLE
use path separator from alembic config

### DIFF
--- a/src/flask_alembic/extension.py
+++ b/src/flask_alembic/extension.py
@@ -197,10 +197,17 @@ class Alembic:
             version_locations.append(version_location)
 
         c.set_main_option("script_location", script_location)
-        c.set_main_option("version_locations", ",".join(version_locations))
+        c.set_main_option(
+            "path_separator", current_app.config["ALEMBIC"]["path_separator"]
+        )
+        path_sep = self._get_file_separator_char(c)
+        c.set_main_option(
+            "version_locations",
+            path_sep.join(version_locations),
+        )
 
         for key, value in current_app.config["ALEMBIC"].items():
-            if key in ("script_location", "version_locations"):
+            if key in ("script_location", "version_locations", "path_separator"):
                 continue
 
             if isinstance(value, dict):
@@ -214,6 +221,22 @@ class Alembic:
             c.set_main_option("databases", ", ".join(self.metadatas))
 
         return cache.config
+
+    def _get_file_separator_char(self, config: Config) -> str:
+        if hasattr(config, "_get_file_separator_char"):
+            # Alembic >= 1.16.0
+            return config._get_file_separator_char("path_separator")  # type: ignore[return-value]
+
+        join_on_path = {
+            "space": " ",
+            "newline": "\n",
+            "os": os.pathsep,
+            ":": ":",
+            ";": ";",
+        }
+        return join_on_path.get(
+            current_app.config["ALEMBIC"].get("version_path_separator"), ","
+        )
 
     @property
     def script_directory(self) -> ScriptDirectory:

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 from click.testing import Result
@@ -40,3 +41,17 @@ def test_no_cli(app: Flask) -> None:
     runner = app.test_cli_runner()
     result: Result = runner.invoke(args=["db", "--help"])
     assert result.exit_code == 2
+
+
+def test_version_locations(app: Flask) -> None:
+    app.config["ALEMBIC"] = {
+        "script_location": "migrations",
+        "version_locations": ["migrations/versions", "versions"],
+    }
+    alembic = Alembic(app)
+    with app.app_context():
+        assert alembic.script_directory.version_locations == [
+            os.path.join(app.root_path, "migrations"),
+            os.path.join(app.root_path, "migrations/versions"),
+            os.path.join(app.root_path, "versions"),
+        ]


### PR DESCRIPTION
Fixes #59 

This issue is easy to miss for apps that don't organize revision scripts into multiple directories.

For alembic >= 1.16.0, get the separator character by calling `Config._get_file_separator_char()`. Because of the changes in #50, "," is never the separator that alembic expects unless `ALEMBIC["path_separator"]` is explicitly set to `None` in the app config.

For Alembic < 1.16.0, use `ALEMBIC["version_path_separator"]` to determine the separator character that alembic expects. If "version_path_separator" is unset or is invalid, then use ",".